### PR TITLE
Increase grid limit to 20 rows

### DIFF
--- a/app/views/partials/_question_group.html.haml
+++ b/app/views/partials/_question_group.html.haml
@@ -11,15 +11,15 @@
               %col{:class => cycle("odd", "even")}
             %col.post
             %tbody
-              - qs.each_slice(10) do |ten_questions| # header row every 10
+              - qs.each_slice(20) do |twenty_questions| # header row every 20
                 %tr
                   %th &nbsp;
-                  - ten_questions.first.answers.each do |a|
+                  - twenty_questions.first.answers.each do |a|
                     %th
                       = a.text_for(nil, @render_context, I18n.locale)
                       %span.help= a.help_text_for(@render_context, I18n.locale)
                   %th &nbsp;
-                - ten_questions.each_with_index do |q, i|
+                - twenty_questions.each_with_index do |q, i|
                   %tr{:id => "q_#{q.id}", :class => "q_#{renderer} #{q.css_class(@response_set)}"}
                     %th
                       = q.text_for(:pre, @render_context, I18n.locale)


### PR DESCRIPTION
For questions displayed in grid format, repeat the list of options after 20 rows instead of 10. 